### PR TITLE
Use Dockerized Ollama via Testcontainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "version": "0.1.1",
   "dependencies": {
     "@langchain/community": "^0.0.44",
+    "@testcontainers/ollama": "^10.13.2",
     "axios": "^1.6.8",
     "ejs": "^3.1.9",
     "express": "^4.19.2",

--- a/server.mjs
+++ b/server.mjs
@@ -8,6 +8,11 @@
  */
 import { Ollama } from "@langchain/community/llms/ollama";
 import express from 'express';
+import { OllamaContainer } from "@testcontainers/ollama";
+
+// Run ollama containers
+const ollamaContainerWithLlama = await new OllamaContainer("ilopezluna/llama3.2:0.3.12-3b").start();
+const ollamaContainerWithPhi = await new OllamaContainer("ilopezluna/phi3.5:0.3.12-3.8b").start();
 
 // Create an Express app
 const app = express();
@@ -47,8 +52,8 @@ app.post('/query', async (req, res) => {
   console.log('☀️ Query:', query);
   try {
     const ollama = new Ollama({
-      baseUrl: "http://localhost:11434",
-      model: "llama3",
+      baseUrl: ollamaContainerWithLlama.getEndpoint(),
+      model: "llama3.2:3b",
     });
     
     const response = await ollama.invoke(query);
@@ -67,11 +72,11 @@ app.post('/query', async (req, res) => {
 app.post('/query2', async (req, res) => {
   let query = req.body.query;
   query = "context: " + context + ". " + query
-  console.log('☀️ Query for phi3:', query);
+  console.log('☀️ Query for phi3.5:', query);
   try {
     const ollama = new Ollama({
-      baseUrl: "http://localhost:11434",
-      model: "phi3",
+      baseUrl: ollamaContainerWithPhi.getEndpoint(),
+      model: "phi3.5:3.8b",
     });
     
     const response = await ollama.invoke(query);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -132,7 +132,7 @@
         <div class="col-md-6">
           <div class="form-group">
             <h3>
-              <label for="chat-log-1">🐑 LLame 3</label>
+              <label for="chat-log-1">🐑 LLama 3.2</label>
               <span
                 id="spinner"
                 class="spinner-border spinner-border-sm d-none"
@@ -164,7 +164,7 @@
         <div class="col-md-6">
           <div class="form-group">
             <h3>
-              <label for="chat-log-2">⛵️ Phi-3</label>
+              <label for="chat-log-2">⛵️ Phi-3.5</label>
               <span
                 id="spinner-mistral"
                 class="spinner-border spinner-border-sm d-none"


### PR DESCRIPTION
Implements #1 

Adds Testcontainers to run an Ollama container for Llama 3.2 and another for Phi 3.5. Both models have been updated to use a newer version.

Note: The first run may take longer as it needs to download the Docker images. After that, it runs as usual.